### PR TITLE
Added test_failed_fit to test_t1.py

### DIFF
--- a/ukat/mapping/tests/test_t1.py
+++ b/ukat/mapping/tests/test_t1.py
@@ -97,6 +97,9 @@ class TestT1:
         assert mapper_two_param.shape == signal_array.shape[:-1]
         # Voxels that fail to fit are set to zero
         assert mapper_two_param.t1_map.mean() == 0.0
+        assert mapper_two_param.t1_err.mean() == 0.0
+        assert mapper_two_param.m0_map.mean() == 0.0
+        assert mapper_two_param.m0_err.mean() == 0.0
 
         # Fail to fit using the 3 parameter equation
         mapper_three_param = T1(signal_array, self.t,
@@ -104,25 +107,28 @@ class TestT1:
         assert mapper_three_param.shape == signal_array.shape[:-1]
         # Voxels that fail to fit are set to zero
         assert mapper_three_param.t1_map.mean() == 0.0
+        assert mapper_three_param.t1_err.mean() == 0.0
+        assert mapper_three_param.m0_map.mean() == 0.0
+        assert mapper_three_param.m0_err.mean() == 0.0
 
     def test_mask(self):
         signal_array = np.tile(self.correct_signal_two_param, (10, 10, 3, 1))
 
         # Bool mask
         mask = np.ones(signal_array.shape[:-1], dtype=bool)
-        mask[:5, :, :] = False
+        mask[:5, ...] = False
         mapper = T1(signal_array, self.t, mask=mask)
         assert mapper.shape == signal_array.shape[:-1]
-        assert mapper.t1_map[5:, :, :].mean() - self.t1 < 0.1
-        assert mapper.t1_map[:5, :, :].mean() < 0.1
+        assert mapper.t1_map[5:, ...].mean() - self.t1 < 0.1
+        assert mapper.t1_map[:5, ...].mean() < 0.1
 
         # Int mask
         mask = np.ones(signal_array.shape[:-1])
-        mask[:5, :, :] = 0
+        mask[:5, ...] = 0
         mapper = T1(signal_array, self.t, mask=mask)
         assert mapper.shape == signal_array.shape[:-1]
-        assert mapper.t1_map[5:, :, :].mean() - self.t1 < 0.1
-        assert mapper.t1_map[:5, :, :].mean() < 0.1
+        assert mapper.t1_map[5:, ...].mean() - self.t1 < 0.1
+        assert mapper.t1_map[:5, ...].mean() < 0.1
 
     def test_missmatched_raw_data_and_inversion_lengths(self):
 


### PR DESCRIPTION
### Proposed changes

Continuation of PR #89 - it was closed too early and @alexdaniel654  raised the issues related with testing failed fitting. The comment is quoted below. This PR is a suggestion on how to approach the failed T1 fitting test.

"
The idea behind this is that some signals will be too noisy for the curve fitting methods to be able to even guess a value for T1. If that happens, curve_fit raises a runtime error but we cant have a hole in our data for that voxel so have to attribute a value to it. That value could be nan but then we would end up with issues when we try and export to nifti as it doesn't support nans so the convention is to assign that voxel to zero (around line 205 in t1.py).

This test is checking that when the fit fails (i.e. the runtime error is thrown) the offending voxels are assigned a value of zero which is the case for the two parameter fit. It looks like the three parameter fit isn't raising the runtime error because the extra parameter in the equation is fitting to enables an estimation of T1, it just happens to be that the estimation of T1 is very close to zero.

The way to fix this is to try and fit worse data so the three parameter fit raises the runtime error and therefore the value of T1 is zero, not just close to zero. i.e. the assert in the tests is correct because every voxel should have been set to zero by np.zeros, it's the input data that needs changing.
"

### Checklists
- [x] The PR is small (so that it can be reviewed quickly)