### PR TITLE
Remove cpu_count from t2star

### DIFF
--- a/ukat/mapping/t2star.py
+++ b/ukat/mapping/t2star.py
@@ -1,15 +1,12 @@
 import warnings
 import numpy as np
-from multiprocessing import cpu_count
 import concurrent.futures
 from tqdm import tqdm
 from scipy.optimize import curve_fit
 
 
 class T2Star(object):
-    """Package containing algorithms that calculate parameter maps
-    of the MRI scans acquired during the UKRIN-MAPS project.
-
+    """
     Attributes
     ----------
     t2star_map : np.ndarray
@@ -124,8 +121,7 @@ class T2Star(object):
 
         # Multithreaded method
         if self.multithread:
-            cores = cpu_count()
-            with concurrent.futures.ProcessPoolExecutor(cores) as pool:
+            with concurrent.futures.ProcessPoolExecutor() as pool:
                 with tqdm(total=idx.size) as progress:
                     futures = []
 


### PR DESCRIPTION
### Proposed changes

Removing unnecessary import of cpu_count from T2* module. Already removed/going to be removed from T1 and T2 in #104 and #105 respectively but raised as its own PR to keep the scope of those clean.
