### PR TITLE
B0 Map correction added for when the unwrapping isn't complete

### DIFF
--- a/ukat/mapping/b0.py
+++ b/ukat/mapping/b0.py
@@ -96,8 +96,8 @@ class B0:
             self.b0_map = self.phase_difference / (2 * np.pi * self.delta_te)
             # Check if the full cycle exists and if so, correct the output
             # B0 Map based on the dynamic range
-            central_pixel_value = np.mean(self.b0_map[int(self.shape[0] / 2), \
-                                                      int(self.shape[1] / 2), \
+            central_pixel_value = np.mean(self.b0_map[int(self.shape[0] / 2),
+                                                      int(self.shape[1] / 2),
                                                       ...])
             dynamic_range = 1 / self.delta_te
             if np.abs(central_pixel_value) > dynamic_range / 2:

--- a/ukat/mapping/b0.py
+++ b/ukat/mapping/b0.py
@@ -94,6 +94,17 @@ class B0:
             self.phase_difference = self.phase1 - self.phase0
             # B0 Map calculation
             self.b0_map = self.phase_difference / (2 * np.pi * self.delta_te)
+            # Check if the full cycle exists and if so, correct the output
+            # B0 Map based on the dynamic range
+            central_pixel_value = np.mean(self.b0_map[int(self.shape[0] / 2), \
+                                                      int(self.shape[1] / 2), \
+                                                      ...])
+            dynamic_range = 1 / self.delta_te
+            if np.abs(central_pixel_value) > dynamic_range / 2:
+                if central_pixel_value + dynamic_range > dynamic_range / 2:
+                    self.b0_map = self.b0_map - dynamic_range
+                else:
+                    self.b0_map = self.b0_map + dynamic_range
         else:
             raise ValueError('The input should contain 2 echo times.'
                              'The last dimension of the input pixel_array must'

--- a/ukat/mapping/b0.py
+++ b/ukat/mapping/b0.py
@@ -94,7 +94,7 @@ class B0:
             self.phase_difference = self.phase1 - self.phase0
             # B0 Map calculation
             self.b0_map = self.phase_difference / (2 * np.pi * self.delta_te)
-            # The following step checks in a central bounding box containing 
+            # The following step checks in a central bounding box containing
             # the kidneys if there is an offset in the B0 Map and corrects
             # that offset if it exists. This is due to a jump in phase
             # that can occurr during the unwrapping of the phase images.

--- a/ukat/mapping/tests/test_b0.py
+++ b/ukat/mapping/tests/test_b0.py
@@ -190,7 +190,7 @@ class TestB0:
         # B0Map with unwrapping
         mapper = B0(images, te, affine, unwrap=True)
         b0_map_without_offset_correction = mapper.phase_difference / \
-                                        (2 * np.pi * mapper.delta_te)
+                                           (2 * np.pi * mapper.delta_te)
         # This assertion proves that no offset correction was performed
         assert (mapper.b0_map == b0_map_without_offset_correction).all()
 
@@ -202,7 +202,7 @@ class TestB0:
         # B0Map with unwrapping
         mapper = B0(images, te, affine, unwrap=True)
         b0_map_without_offset_correction = mapper.phase_difference / \
-                                        (2 * np.pi * mapper.delta_te)
+                                           (2 * np.pi * mapper.delta_te)
         # This assertion proves that there was offset correction performed
         assert (mapper.b0_map != b0_map_without_offset_correction).any()
 

--- a/ukat/mapping/tests/test_b0.py
+++ b/ukat/mapping/tests/test_b0.py
@@ -181,6 +181,30 @@ class TestB0:
                             b0map_stats["min"], b0map_stats["max"]],
                             gold_standard_b0, rtol=0.01, atol=0)
 
+    def test_b0_offset_correction(self):
+        # Get test data that does not require b0_offset correction
+        magnitude, phase, affine, te = fetch.b0_philips()
+        te *= 1000
+        # Process on a central slice only
+        images = phase[:, :, 4, :]
+        # B0Map with unwrapping
+        mapper = B0(images, te, affine, unwrap=True)
+        b0_map_without_offset_correction = mapper.phase_difference / \
+                                        (2 * np.pi * mapper.delta_te)
+        # This assertion proves that no offset correction was performed
+        assert (mapper.b0_map == b0_map_without_offset_correction).all()
+
+        # Get test data that requires b0_offset correction
+        magnitude, phase, affine, te = fetch.b0_siemens(1)
+        te *= 1000
+        # Process on a central slice only
+        images = phase[:, :, 4, :]
+        # B0Map with unwrapping
+        mapper = B0(images, te, affine, unwrap=True)
+        b0_map_without_offset_correction = mapper.phase_difference / \
+                                        (2 * np.pi * mapper.delta_te)
+        # This assertion proves that there was offset correction performed
+        assert (mapper.b0_map != b0_map_without_offset_correction).any()
 
 # Delete the NIFTI test folder recursively if any of the unit tests failed
 if os.path.exists('test_output'):

--- a/ukat/mapping/tests/test_b0.py
+++ b/ukat/mapping/tests/test_b0.py
@@ -189,8 +189,8 @@ class TestB0:
         images = phase[:, :, 4, :]
         # B0Map with unwrapping
         mapper = B0(images, te, affine, unwrap=True)
-        b0_map_without_offset_correction = mapper.phase_difference / \
-                                           (2 * np.pi * mapper.delta_te)
+        b0_map_without_offset_correction = (mapper.phase_difference /
+                                            (2 * np.pi * mapper.delta_te))
         # This assertion proves that no offset correction was performed
         assert (mapper.b0_map == b0_map_without_offset_correction).all()
 
@@ -201,8 +201,8 @@ class TestB0:
         images = phase[:, :, 4, :]
         # B0Map with unwrapping
         mapper = B0(images, te, affine, unwrap=True)
-        b0_map_without_offset_correction = mapper.phase_difference / \
-                                           (2 * np.pi * mapper.delta_te)
+        b0_map_without_offset_correction = (mapper.phase_difference /
+                                            (2 * np.pi * mapper.delta_te))
         # This assertion proves that there was offset correction performed
         assert (mapper.b0_map != b0_map_without_offset_correction).any()
 

--- a/ukat/utils/tools.py
+++ b/ukat/utils/tools.py
@@ -21,9 +21,7 @@ def convert_to_pi_range(pixel_array):
         An array containing with the same shape as pixel_array
         scaled to the range [-pi, pi].
     """
-    if (np.amax(pixel_array) > 3.2) or (np.amin(pixel_array) < -3.2):
-        # The value 3.2 was chosen instead of np.pi in order
-        # to give some margin.
+    if (np.amax(pixel_array) > np.pi) or (np.amin(pixel_array) < -np.pi):
         pi_array = np.pi * np.ones(np.shape(pixel_array))
         min_array = np.amin(pixel_array) * np.ones(np.shape(pixel_array))
         max_array = np.amax(pixel_array) * np.ones(np.shape(pixel_array))


### PR DESCRIPTION
### Proposed changes

This Pull Request deals with the cases where the unwrapping of the phase images in B0 isn't complete. The bit of code written adds/subtracts `1/deltaTE` to the resulting B0Map. Please have a look at the changes and at the wording as well. This was tested with a dataset provided by @charlotteebuchanan 