### PR TITLE
Reference Manual part 2

### DIFF
--- a/.github/workflows/reference_manual.yml
+++ b/.github/workflows/reference_manual.yml
@@ -1,8 +1,11 @@
 name: Upload manual to Github Page
 on:
   push:
-    branches:
-      - master
+    tags-ignore:
+      - 'v*rc*'
+    tags:
+      - 'v*'
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Added Github Action to generate documentation when a tag release (and not tag release candidate) is created
