### PR TITLE
T1 single slice

### DIFF
--- a/ukat/mapping/t1.py
+++ b/ukat/mapping/t1.py
@@ -97,8 +97,7 @@ class T1:
             self.tss_axis = tss_axis % self.dimensions
         else:
             self.tss_axis = None
-            assert (self.tss == 0), \
-                'tss should be zero for single slice T1 fitting'
+            self.tss = 0
         self.parameters = parameters
         self.multithread = multithread
 

--- a/ukat/mapping/t1.py
+++ b/ukat/mapping/t1.py
@@ -22,7 +22,7 @@ class T1:
         The estimated inversion efficiency where 0 represents no inversion
         pulse and 2 represents a 180 degree inversion
     eff_err : np.ndarray
-        The certianty in the fit of `eff`
+        The certainty in the fit of `eff`
     shape : tuple
         The shape of the T1 map
     n_ti : int
@@ -53,6 +53,8 @@ class T1:
             The axis over which the temporal slice spacing is applied. This
             axis is relative to the full 4D pixel array i.e. tss_axis=-1
             would be along the TI axis and would be meaningless.
+            If `pixel_array` is single slice (dimensions [x, y, TI]),
+            then this should be set to None.
         affine : np.ndarray
             A matrix giving the relationship between voxel coordinates and
             world coordinates.
@@ -91,7 +93,10 @@ class T1:
         self.mask[np.isnan(np.sum(pixel_array, axis=-1))] = False
         self.inversion_list = inversion_list
         self.tss = tss
-        self.tss_axis = tss_axis % self.dimensions
+        if tss_axis is not None:
+            self.tss_axis = tss_axis % self.dimensions
+        else:
+            self.tss_axis = None
         self.parameters = parameters
         self.multithread = multithread
 
@@ -105,6 +110,8 @@ class T1:
                 'Temporal slice spacing can\'t be applied to the TI axis.'
             assert (tss_axis < self.dimensions), \
                 'tss_axis must be less than the number of spatial dimensions'
+            assert (self.tss_axis is None), \
+                'tss should be zero for single slice T1 fitting'
 
         # Initialise output attributes
         self.t1_map = np.zeros(self.shape)

--- a/ukat/mapping/t1.py
+++ b/ukat/mapping/t1.py
@@ -97,6 +97,8 @@ class T1:
             self.tss_axis = tss_axis % self.dimensions
         else:
             self.tss_axis = None
+            assert (self.tss == 0), \
+                'tss should be zero for single slice T1 fitting'
         self.parameters = parameters
         self.multithread = multithread
 
@@ -110,8 +112,6 @@ class T1:
                 'Temporal slice spacing can\'t be applied to the TI axis.'
             assert (tss_axis < self.dimensions), \
                 'tss_axis must be less than the number of spatial dimensions'
-            assert (self.tss_axis is None), \
-                'tss should be zero for single slice T1 fitting'
 
         # Initialise output attributes
         self.t1_map = np.zeros(self.shape)

--- a/ukat/mapping/tests/test_t1.py
+++ b/ukat/mapping/tests/test_t1.py
@@ -246,6 +246,12 @@ class TestT1:
                         inversion_list=np.linspace(0, 2000, 10),
                         affine=self.affine, tss=1, tss_axis=2)
 
+        # Single Slice with tss != 0
+        with pytest.raises(AssertionError):
+            mapper = T1(pixel_array=np.zeros((5, 5, 10)),
+                        inversion_list=np.linspace(0, 2000, 10),
+                        affine=self.affine, tss=1, tss_axis=None)
+
     def test_real_data(self):
         # Get test data
         magnitude, phase, affine, ti, tss = fetch.t1_philips(2)
@@ -260,6 +266,7 @@ class TestT1:
         # Gold standard statistics
         gold_standard_2p = [1041.581031, 430.129308, 241.512336, 2603.911794]
         gold_standard_3p = [1405.617672, 596.71554, 281.406566, 3759.175897]
+        gold_standard_3p_single = [1329.543147, 582.270541, 281.406569, 3334.1764436]
 
         # Two parameter method
         mapper = T1(magnitude, ti, affine, parameters=2, tss=tss)
@@ -274,6 +281,14 @@ class TestT1:
         npt.assert_allclose([t1_stats['mean']['3D'], t1_stats['std']['3D'],
                              t1_stats['min']['3D'], t1_stats['max']['3D']],
                             gold_standard_3p, rtol=1e-6, atol=5e-3)
+        
+        # Three parameter method for first slice only
+        mapper = T1(magnitude[:, :, 0, :], ti, affine, parameters=3,
+                    tss=0, tss_axis=None)
+        t1_stats = arraystats.ArrayStats(mapper.t1_map).calculate()
+        npt.assert_allclose([t1_stats['mean'], t1_stats['std'],
+                             t1_stats['min'], t1_stats['max']],
+                            gold_standard_3p_single, rtol=1e-6, atol=5e-3)
 
     def test_to_nifti(self):
         # Create a T1 map instance and test different export to NIFTI scenarios

--- a/ukat/mapping/tests/test_t1.py
+++ b/ukat/mapping/tests/test_t1.py
@@ -246,12 +246,6 @@ class TestT1:
                         inversion_list=np.linspace(0, 2000, 10),
                         affine=self.affine, tss=1, tss_axis=2)
 
-        # Single Slice with tss != 0
-        with pytest.raises(AssertionError):
-            mapper = T1(pixel_array=np.zeros((5, 5, 10)),
-                        inversion_list=np.linspace(0, 2000, 10),
-                        affine=self.affine, tss=1, tss_axis=None)
-
     def test_real_data(self):
         # Get test data
         magnitude, phase, affine, ti, tss = fetch.t1_philips(2)

--- a/ukat/mapping/tests/test_t1.py
+++ b/ukat/mapping/tests/test_t1.py
@@ -275,7 +275,7 @@ class TestT1:
         t1_stats = arraystats.ArrayStats(mapper.t1_map).calculate()
         npt.assert_allclose([t1_stats['mean']['3D'], t1_stats['std']['3D'],
                              t1_stats['min']['3D'], t1_stats['max']['3D']],
-                             gold_standard_3p, rtol=1e-6, atol=5e-3)
+                            gold_standard_3p, rtol=1e-6, atol=5e-3)
 
         # Three parameter method for first slice only
         mapper = T1(magnitude[:, :, 0, :], ti, affine, parameters=3,

--- a/ukat/mapping/tests/test_t1.py
+++ b/ukat/mapping/tests/test_t1.py
@@ -260,7 +260,8 @@ class TestT1:
         # Gold standard statistics
         gold_standard_2p = [1041.581031, 430.129308, 241.512336, 2603.911794]
         gold_standard_3p = [1405.617672, 596.71554, 281.406566, 3759.175897]
-        gold_standard_3p_single = [1329.543147, 582.270541, 281.406569, 3334.1764436]
+        gold_standard_3p_single = [1329.543147, 582.270541, 281.406569,
+                                   3334.1764436]
 
         # Two parameter method
         mapper = T1(magnitude, ti, affine, parameters=2, tss=tss)
@@ -274,8 +275,8 @@ class TestT1:
         t1_stats = arraystats.ArrayStats(mapper.t1_map).calculate()
         npt.assert_allclose([t1_stats['mean']['3D'], t1_stats['std']['3D'],
                              t1_stats['min']['3D'], t1_stats['max']['3D']],
-                            gold_standard_3p, rtol=1e-6, atol=5e-3)
-        
+                             gold_standard_3p, rtol=1e-6, atol=5e-3)
+
         # Three parameter method for first slice only
         mapper = T1(magnitude[:, :, 0, :], ti, affine, parameters=3,
                     tss=0, tss_axis=None)


### PR DESCRIPTION
### Proposed changes

At the moment, if the user provides an input `pixel_array` with the shape (x, y, ti) instead of (x, y, z, ti), the code will return an IndexError. The T1 map calculation assumes that the input image is always a set of 3D volumes where each volume corresponds to 1 Inversion Time (ti).

This Pull Request is a suggestion of how to deal with both single-slice and 3D volumes T1 sequences. By setting the `tss_axis` optional argument to `None` the user is explicitly "telling" the class that the input `pixel_array` is single-slice.

At the moment the [MDR package] (https://github.com/QIB-Sheffield/MDR-Library) can only work with single-slice images, which means that the current ukat T1 model (which only works with 3D images) isn't compatible with the model-driven registration method that we currently have. Ultimately, this is the real reason why I'm opening this Pull Request because as things stand at the moment, I'm unable to use the T1 ukat within the MDR-Library.
