### PR TITLE
import whole_kidney in segmentation __init__.py

### DIFF
--- a/ukat/segmentation/__init__.py
+++ b/ukat/segmentation/__init__.py
@@ -1,0 +1,1 @@
+from . import whole_kidney


### PR DESCRIPTION
### Proposed changes

While using ukat 0.5.0, I noticed that I wasn't able to import whole_kidney.py as a package just like the ones in the "mapping" folder. This PR adds that import to the empty `__init__.py` in the "segmentation" folder.