### PR TITLE
GE B1 Map Scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.6.1] - 2022-08-03
+
+### Added
+* Whole kidney segmentation can now be performed using custom models. #187
+
+### Changed
+* Python 3.7 is no longer supported.
+
+### Fixed
+
 ## [0.6.0] - 2022-02-28
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,23 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Daniel"
+  given-names: "Alexander J"
+  orcid: "https://orcid.org/0000-0003-2353-3283"
+- family-names: "Nery"
+  given-names: "Fabio"
+  orcid: "https://orcid.org/0000-0002-4220-0997"
+- family-names: "Almeida e Sousa"
+  given-names: "Joao"
+  orcid: "https://orcid.org/0000-0002-6668-7613"
+- family-names: "Buchanan"
+  given-names: "Charlotte E"
+  orcid: "https://orcid.org/0000-0003-3010-6079"
+- family-names: "Francis"
+  given-names: "Susan T"
+  orcid: "https://orcid.org/0000-0003-0903-7507"
+title: "UKRIN Kidney Analysis Toolbox"
+version: 0.6.1
+doi: 10.5281/zenodo.4742470
+date-released: 2022-08-03
+url: "https://github.com/UKRIN-MAPS/ukat"

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.md', encoding='utf-8') as f:
 
 setup(
     name="ukat",
-    version="0.6.0",
+    version="0.6.1",
     description="UKRIN Kidney Analysis Toolbox",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/ukat/utils/__init__.py
+++ b/ukat/utils/__init__.py
@@ -1,1 +1,1 @@
-from . import arraystats, siemens, tools
+from . import arraystats, ge, siemens, tools

--- a/ukat/utils/ge.py
+++ b/ukat/utils/ge.py
@@ -1,0 +1,23 @@
+def scale_b1(data, flip_angle):
+    """
+    Scale the B1 map produced by GE scanners to be a percentage of the
+    nominal flip angle.
+
+    Its advisable to verify the velocity encode scale (dicom tag (0019,
+    10E2)) is 299.97.
+
+    Parameters
+    ----------
+    data : np.ndarray
+        The B1 map to be scaled.
+    flip_angle : float
+        The flip angle of the sequence.
+
+    Returns
+    -------
+    scaled_data : np.ndarray
+        The scaled B1 map.
+    """
+    norm_factor = 10 / flip_angle
+    b1_scaled = data * norm_factor
+    return b1_scaled

--- a/ukat/utils/tests/__init__.py
+++ b/ukat/utils/tests/__init__.py
@@ -1,1 +1,1 @@
-from . import test_arraystats, test_siemens, test_tools
+from . import test_arraystats, test_ge, test_siemens, test_tools

--- a/ukat/utils/tests/test_ge.py
+++ b/ukat/utils/tests/test_ge.py
@@ -1,0 +1,11 @@
+import numpy as np
+import pytest
+from ukat.utils.ge import scale_b1
+
+
+class TestScaleB1:
+    unscalled_b1 = np.ones((10, 10, 5)) * 200
+
+    def test_scale_b1(self):
+        scaled_b1 = scale_b1(self.unscalled_b1, 20)
+        assert np.allclose(scaled_b1, 100)


### PR DESCRIPTION
### Proposed changes

GE B1 maps are exported scaled by the flip angle. This PR adds a small function to rescale the maps to a percentage of nominal flip angle.

### Checklists

- [x] I have read and followed the [CONTRIBUTING](.github/CONTRIBUTING.md) document
- [x] This pull request is from and to the dev branch
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated documentation which becomes obsolete after my changes (if appropriate)
- [x] Files added follow the repository structure (if appropriate)