### PR TITLE
B0 Mask

### DIFF
--- a/ukat/mapping/b0.py
+++ b/ukat/mapping/b0.py
@@ -80,10 +80,10 @@ class B0:
             # [-pi, pi] if not in that range already.
             self.phase0 = np.ma.masked_array(
                             convert_to_pi_range(np.squeeze(
-                                self.pixel_array[..., 0])), mask=mask)
+                                self.pixel_array[..., 0])), mask=~mask)
             self.phase1 = np.ma.masked_array(
                             convert_to_pi_range(np.squeeze(
-                                self.pixel_array[..., 1])), mask=mask)
+                                self.pixel_array[..., 1])), mask=~mask)
             if unwrap:
                 # Unwrap each phase image
                 self.phase0 = unwrap_phase(self.phase0,
@@ -110,6 +110,9 @@ class B0:
             b0_offset_step = 1 / self.delta_te
             # B0 Map Offset Correction
             self.b0_map -= (mean_central_b0 // b0_offset_step) * b0_offset_step
+            
+            # Mask B0 Map
+            self.b0_map[~mask] = 0
         else:
             raise ValueError('The input should contain 2 echo times.'
                              'The last dimension of the input pixel_array must'

--- a/ukat/mapping/b0.py
+++ b/ukat/mapping/b0.py
@@ -80,10 +80,10 @@ class B0:
             # [-pi, pi] if not in that range already.
             self.phase0 = np.ma.masked_array(
                             convert_to_pi_range(np.squeeze(
-                                self.pixel_array[..., 0])), mask=~mask)
+                                self.pixel_array[..., 0])), mask=~self.mask)
             self.phase1 = np.ma.masked_array(
                             convert_to_pi_range(np.squeeze(
-                                self.pixel_array[..., 1])), mask=~mask)
+                                self.pixel_array[..., 1])), mask=~self.mask)
             if unwrap:
                 # Unwrap each phase image
                 self.phase0 = unwrap_phase(self.phase0,
@@ -112,7 +112,7 @@ class B0:
             self.b0_map -= (mean_central_b0 // b0_offset_step) * b0_offset_step
             
             # Mask B0 Map
-            self.b0_map[~mask] = 0
+            self.b0_map[~self.mask] = 0
         else:
             raise ValueError('The input should contain 2 echo times.'
                              'The last dimension of the input pixel_array must'


### PR DESCRIPTION
### Proposed changes

B0 mask currently works the opposite of the rest of `ukat. Additionally, the mask is only used in the unwrapping process, the resulting B0 map is unmasked.

Will close #194

### Checklists

- [x] I have read and followed the [CONTRIBUTING](.github/CONTRIBUTING.md) document
- [x] This pull request is from and to the dev branch
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated documentation which becomes obsolete after my changes (if appropriate)
- [x] Files added follow the repository structure (if appropriate)
