### PR TITLE
M0 bounds

### DIFF
--- a/ukat/mapping/t1.py
+++ b/ukat/mapping/t1.py
@@ -234,14 +234,14 @@ class T1:
 
         # Initialise parameters and specify equation to fit to
         if parameters == 2:
-            bounds = ([0, 0], [5000, 10000000])
+            bounds = ([0, 0], [5000, 1000000000])
             initial_guess = [1000, 30000]
             if sig.min() >= 0:
                 eq = two_param_abs_eq
             else:
                 eq = two_param_eq
         elif parameters == 3:
-            bounds = ([0, 0, 1], [5000, 10000000, 2])
+            bounds = ([0, 0, 1], [5000, 1000000000, 2])
             initial_guess = [1000, 30000, 2]
             if sig.min() >= 0:
                 eq = three_param_abs_eq

--- a/ukat/mapping/t2.py
+++ b/ukat/mapping/t2.py
@@ -197,11 +197,11 @@ class T2:
         # Initialise parameters
         if self.method == '2p_exp':
             eq = two_param_eq
-            bounds = ([0, 0], [1000, 1000000])
+            bounds = ([0, 0], [1000, 100000000])
             initial_guess = [20, 10000]
         elif self.method == '3p_exp':
             eq = three_param_eq
-            bounds = ([0, 0, 0], [1000, 1000000, 1000000])
+            bounds = ([0, 0, 0], [1000, 100000000, 1000000])
             initial_guess = [20, 10000, 500]
 
         # Fit data to equation

--- a/ukat/mapping/t2star.py
+++ b/ukat/mapping/t2star.py
@@ -222,7 +222,7 @@ class T2Star:
 
         elif method == '2p_exp':
             # Initialise parameters
-            bounds = ([0, 0], [700, 1000000])
+            bounds = ([0, 0], [700, 100000000])
             initial_guess = [20, 10000]
 
             # Fit data to equation


### PR DESCRIPTION
### Proposed changes

I've encountered the M0 bounds of both the T1 and T2 mapping methods to be too low. Here I've increased the bounds of these methods and the T2* mapping exponential fitting method.

### Checklists

- [x] I have read and followed the [CONTRIBUTING](.github/CONTRIBUTING.md) document
- [x] This pull request is from and to the dev branch
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated documentation which becomes obsolete after my changes (if appropriate)
- [x] Files added follow the repository structure (if appropriate)