### PR TITLE
Adjust B0 offset Calculation

### DIFF
--- a/ukat/mapping/b0.py
+++ b/ukat/mapping/b0.py
@@ -97,22 +97,23 @@ class B0:
             # The following step checks in a central bounding box containing
             # the kidneys if there is an offset in the B0 Map and corrects
             # that offset if it exists. This is due to a jump in phase
-            # that can occurr during the unwrapping of the phase images.
+            # that can occur during the unwrapping of the phase images.
             # Bounding Box
             prop = 0.5
             bx0 = int(self.shape[0] / 2 - prop / 2 * self.shape[0])
             bxf = int(self.shape[0] / 2 + prop / 2 * self.shape[0])
             by0 = int(self.shape[1] / 2 - prop / 2 * self.shape[1])
             byf = int(self.shape[1] / 2 + prop / 2 * self.shape[1])
-            # B0 Map Mean inside the bounding box accross the slices
+            # B0 Map Mean inside the bounding box across the slices
             mean_central_b0 = np.mean(self.b0_map[bx0:bxf, by0:byf, ...])
             # B0 Map Offset Step
             b0_offset_step = 1 / self.delta_te
             # B0 Map Offset Correction
-            self.b0_map -= (mean_central_b0 // b0_offset_step) * b0_offset_step
+            self.b0_map -= (np.round(mean_central_b0 / b0_offset_step)) * \
+                           b0_offset_step
             
             # Mask B0 Map
-            self.b0_map[~self.mask] = 0
+            self.b0_map[np.squeeze(~self.mask)] = 0
         else:
             raise ValueError('The input should contain 2 echo times.'
                              'The last dimension of the input pixel_array must'

--- a/ukat/mapping/tests/test_b0.py
+++ b/ukat/mapping/tests/test_b0.py
@@ -3,6 +3,8 @@ import shutil
 import numpy as np
 import numpy.testing as npt
 import pytest
+
+from skimage.restoration import unwrap_phase
 from ukat.data import fetch
 from ukat.mapping.b0 import B0
 from ukat.utils import arraystats
@@ -197,8 +199,12 @@ class TestB0:
         # Get test data that requires b0_offset correction
         magnitude, phase, affine, te = fetch.b0_siemens(1)
         te *= 1000
+        # Add some extra offset to second TE. B0 maps will be corrupted,
+        # but this still causes the offset correction to be applied.
+        phase[..., 1] = np.angle(
+            np.exp(1j * (unwrap_phase(phase[..., 1]) + np.pi * 1.3)))
         # Process on a central slice only
-        images = phase[:, :, 4, :]
+        images = phase[:, 4, :, :]
         # B0Map with unwrapping
         mapper = B0(images, te, affine, unwrap=True)
         b0_map_without_offset_correction = (mapper.phase_difference /


### PR DESCRIPTION
### Proposed changes

The number of B0 offset steps to apply was calculated with floor rounding, this meant that if the mean of the centre of the B0 map was slightly below zero, a whole offset step was applied. The number of steps is now calculated using normal rounding.

### Checklists

- [x] I have read and followed the [CONTRIBUTING](.github/CONTRIBUTING.md) document
- [x] This pull request is from and to the dev branch
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated documentation which becomes obsolete after my changes (if appropriate)
- [x] Files added follow the repository structure (if appropriate)