### PR TITLE
Squeeze MTR Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ![Build and Test](https://github.com/UKRIN-MAPS/ukat/workflows/Build%20and%20Test/badge.svg?branch=master)
 [![codecov](https://codecov.io/gh/UKRIN-MAPS/ukat/branch/master/graph/badge.svg?token=QJ9DQONJBP)](https://codecov.io/gh/UKRIN-MAPS/ukat)
 [![PyPI version](https://badge.fury.io/py/ukat.svg)](https://badge.fury.io/py/ukat)
+[![Downloads](https://static.pepy.tech/badge/ukat)](https://pepy.tech/project/ukat)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![DOI](https://zenodo.org/badge/256993671.svg)](https://zenodo.org/badge/latestdoi/256993671)
 

--- a/ukat/mapping/mtr.py
+++ b/ukat/mapping/mtr.py
@@ -64,12 +64,12 @@ class MTR:
         else:
             self.mask = mask
         # The assumption is that MT_OFF comes first in `pixel_array`
-        self.mt_off = self.pixel_array[..., 0] * self.mask
+        self.mt_off = np.sequeeze(self.pixel_array[..., 0] * self.mask)
         # The assumption is that MT_ON comes second in `pixel_array`
-        self.mt_on = self.pixel_array[..., 1] * self.mask
+        self.mt_on = np.squeeze(self.pixel_array[..., 1] * self.mask)
         # Magnetisation Transfer Ratio calculation
-        self.mtr_map = np.nan_to_num(((self.mt_off - self.mt_on) /
-                                     self.mt_off), posinf=0, neginf=0)
+        self.mtr_map = np.squeeze(np.nan_to_num(((self.mt_off - self.mt_on) /
+                                     self.mt_off), posinf=0, neginf=0))
 
     def to_nifti(self, output_directory=os.getcwd(), base_file_name='Output',
                  maps='all'):

--- a/ukat/mapping/mtr.py
+++ b/ukat/mapping/mtr.py
@@ -64,7 +64,7 @@ class MTR:
         else:
             self.mask = mask
         # The assumption is that MT_OFF comes first in `pixel_array`
-        self.mt_off = np.sequeeze(self.pixel_array[..., 0] * self.mask)
+        self.mt_off = np.squeeze(self.pixel_array[..., 0] * self.mask)
         # The assumption is that MT_ON comes second in `pixel_array`
         self.mt_on = np.squeeze(self.pixel_array[..., 1] * self.mask)
         # Magnetisation Transfer Ratio calculation


### PR DESCRIPTION
### Proposed changes

The MTR maps produced by ukat have a bonus dimension. I've just squeezed the output.

### Checklists

- [x] I have read and followed the [CONTRIBUTING](.github/CONTRIBUTING.md) document
- [x] This pull request is from and to the dev branch
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated documentation which becomes obsolete after my changes (if appropriate)
- [x] Files added follow the repository structure (if appropriate)