### PR TITLE
Add Python 3.11 Support

### DIFF
--- a/.github/workflows/python_CI.yml
+++ b/.github/workflows/python_CI.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ pathos>=0.3.0
 renalsegmentor>=1.3.5
 scikit-image>=0.20.0, <0.22
 scipy>=1.9.1, <1.12
-scikit-learn~=1.0.0 # Change to >=1.0, <1.3 if this works
+scikit-learn~=1.1  # >=1.1, <1.3  # 1.3 is known to cause changes in iSNR results
 tabulate>=0.9.0
 tqdm>=4.64.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
-dipy~=1.6.0
-matplotlib~=3.7.0
+dipy>=1.6.0
+matplotlib>=3.7.0
 nibabel>=5.0.1
-notebook~=6.5.1
-numba~=0.57.1
-numpy~=1.24.1
-pandas~=2.0.2
-pathos~=0.3.0
+notebook>=6.5.1
+numba>=0.55.1, <0.58
+numpy>=1.24.1, <1.26
+pandas>=2.0.0
+pathos>=0.3.0
 renalsegmentor>=1.3.5
-scikit-image~=0.21.0
-scipy~=1.9.1
-scikit-learn~=1.2.1
-tabulate~=0.9.0
-tqdm~=4.64.1
+scikit-image>=0.20.0, <0.22
+scipy>=1.9.1, <1.12
+scikit-learn~=1.3.0 # Change to >=1.2.1, <1.4 if this works
+tabulate>=0.9.0
+tqdm>=4.64.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ pathos>=0.3.0
 renalsegmentor>=1.3.5
 scikit-image>=0.20.0, <0.22
 scipy>=1.9.1, <1.12
-scikit-learn~=1.1  # >=1.1, <1.3  # 1.3 is known to cause changes in iSNR results
+scikit-learn~=1.2.1  # Changing versions is known to cause changes in iSNR results
 tabulate>=0.9.0
 tqdm>=4.64.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ pathos>=0.3.0
 renalsegmentor>=1.3.5
 scikit-image>=0.20.0, <0.22
 scipy>=1.9.1, <1.12
-scikit-learn~=1.3.0 # Change to >=1.2.1, <1.4 if this works
+scikit-learn~=1.0.0 # Change to >=1.0, <1.3 if this works
 tabulate>=0.9.0
 tqdm>=4.64.1

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
     ],
 )


### PR DESCRIPTION
### Proposed changes

Adding support for Python 3.11. Also rejigging requirements a bit so they not quite so strict but still keep the core packages that will effect results pinned to known good versions.

### Checklists

- [x] I have read and followed the [CONTRIBUTING](.github/CONTRIBUTING.md) document
- [x] This pull request is from and to the dev branch
- [x] I have added tests that demonstrate the feature/fix works
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated documentation which becomes obsolete after my changes (if appropriate)
- [x] I have added/updated a notebook to demonstrate the changes (if appropriate)
- [x] Files added follow the repository structure (if appropriate)
