### PR TITLE
Rescaling of B1 maps

### DIFF
--- a/ukat/mapping/t2_stimfit.py
+++ b/ukat/mapping/t2_stimfit.py
@@ -477,7 +477,7 @@ class T2StimFit:
         self.m0_map = np.squeeze(m0_map.reshape((*self.shape,
                                                  self.model.n_comp)))
         self.b1_map = b1_map.reshape(self.shape)
-        self.b1_map_scaled = rescale_b1_map(self.b1_map)
+        self.b1_map_scaled = rescale_b1_map(self.b1_map * 100)
         self.r2_map = np.squeeze(r2_map.reshape((*self.shape,
                                                  self.model.n_comp)))
 

--- a/ukat/mapping/tests/test_t2_stimfit.py
+++ b/ukat/mapping/tests/test_t2_stimfit.py
@@ -214,8 +214,9 @@ class TestT2StimFit:
         mapper.to_nifti(output_directory='test_output',
                         base_file_name='t2stimfittest', maps='all')
         output_files = os.listdir('test_output')
-        assert len(output_files) == 5
+        assert len(output_files) == 6
         assert 't2stimfittest_b1_map.nii.gz' in output_files
+        assert 't2stimfittest_b1_map_scaled.nii.gz' in output_files
         assert 't2stimfittest_m0_map.nii.gz' in output_files
         assert 't2stimfittest_mask.nii.gz' in output_files
         assert 't2stimfittest_r2_map.nii.gz' in output_files

--- a/ukat/utils/tests/test_tools.py
+++ b/ukat/utils/tests/test_tools.py
@@ -52,6 +52,25 @@ class TestConvertToPiRange:
             tools.convert_to_pi_range("abcdef")
 
 
+class TestRescaleB1Map:
+    unscaled_b1_map = prescaled_b1_map = (
+        np.concatenate((np.linspace(90, 100, 25),
+                        np.linspace(100, 110, 25)),
+                       axis=0).reshape((5, 5, 2)))
+    prescaled_b1_map = (
+        np.concatenate((np.linspace(0.9, 1, 25),
+                       np.linspace(1, 0.9, 25)),
+                       axis=0).reshape((5, 5, 2)))
+
+    def test_rescale(self):
+        rescaled_b1_map = tools.rescale_b1_map(self.unscaled_b1_map)
+        npt.assert_allclose(rescaled_b1_map, self.prescaled_b1_map)
+
+    def test_warning_of_prescaled_data(self):
+        with pytest.warns(UserWarning):
+            tools.rescale_b1_map(self.prescaled_b1_map)
+
+
 class TestResizeArray:
     # Create arrays for testing
     array_2d = np.arange(100).reshape((10, 10))

--- a/ukat/utils/tools.py
+++ b/ukat/utils/tools.py
@@ -4,6 +4,8 @@ multiple algorithms
 
 """
 import numpy as np
+import warnings
+
 from scipy.ndimage import zoom
 
 
@@ -31,6 +33,35 @@ def convert_to_pi_range(pixel_array):
         # It means it's already on the interval [-pi, pi]
         radians_array = pixel_array
     return radians_array
+
+
+def rescale_b1_map(b1_map):
+    """
+    Some method of estimating B1 cannot distinguish B1 values x degrees over
+    the nominal flip angle from x degrees under the nominal flip angle. It can
+    therefore be useful to reflect all values over 100% of the nominal flip
+    angle. To avoid confusion between reflected and un-reflected B1 maps,
+    this function is designed to take B1 maps as a percentage of the nominal
+    flip angle and output them as a ratio between 0 and 1.
+
+    Parameters
+    ----------
+    b1_map : np.ndarray
+        B1 map in percentage of nominal flip angle.
+
+    Returns
+    -------
+    b1_scaled : np.ndarray
+        B1 map scaled to the range [0, 1] where flip angles over 100% are
+        reflected back.
+    """
+    if np.amax(b1_map) <= 1:
+        warnings.warn(f"This function is designed to take the B1 map as a "
+                      f"percentage of the nominal flip angle. The maximum of "
+                      f"the input B1 map is {np.amax(b1_map)}. Are you sure "
+                      f"you haven't already scaled your B1 map?")
+    b1_scaled = 1 - np.abs(1 - (b1_map / 100))
+    return b1_scaled
 
 
 def resize_array(pixel_array, factor=1, target_size=None):


### PR DESCRIPTION
### Proposed changes
Adding function to rescale B1 maps to allow comparison of those output by StimFit and acquired on the scanner. This functionality is also added to the StimFit class.

### Checklists

- [x] I have read and followed the [CONTRIBUTING](.github/CONTRIBUTING.md) document
- [x] This pull request is from and to the dev branch
- [x] I have added tests that demonstrate the feature/fix works
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated documentation which becomes obsolete after my changes (if appropriate)
- [x] I have added/updated a notebook to demonstrate the changes (if appropriate)
- [x] Files added follow the repository structure (if appropriate)