### PR TITLE
T1 Magnitude Correct Data Detection

### DIFF
--- a/.github/workflows/python_CI.yml
+++ b/.github/workflows/python_CI.yml
@@ -49,3 +49,5 @@ jobs:
         env_vars: OS,PYTHON
         fail_ci_if_error: true
         verbose: false
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/ukat/mapping/t1.py
+++ b/ukat/mapping/t1.py
@@ -52,8 +52,23 @@ class T1Model(fitting.Model):
         self.tss = tss
         self.tss_axis = tss_axis
 
+        # Assume the data has been magnitude corrected if the first
+        # percentile of the first inversion time is negative.
         if np.percentile(pixel_array[..., 0], 1) < 0:
             self.mag_corr = True
+            neg_percent = (np.sum(pixel_array[..., 0] < 0)
+                           / pixel_array[..., 0].size)
+            if neg_percent < 0.05:
+                warnings.warn('Fitting data to a magnitude corrected '
+                              'inversion recovery curve however, less than 5% '
+                              'of the data from the first inversion is '
+                              'negative. If you have performed magnitude '
+                              'correction ignore this warning, otherwise the '
+                              'negative values could be due to noise or '
+                              'preprocessing steps  such as EPI distortion '
+                              'correction and  registration.\n'
+                              f'Percentage of first inversion data that is '
+                              f'negative = {neg_percent:.2%}')
         else:
             self.mag_corr = False
             if np.nanmin(pixel_array) < 0:

--- a/ukat/mapping/t1.py
+++ b/ukat/mapping/t1.py
@@ -52,10 +52,21 @@ class T1Model(fitting.Model):
         self.tss = tss
         self.tss_axis = tss_axis
 
-        if np.nanmin(pixel_array) < 0:
+        if np.percentile(pixel_array[..., 0], 1) < 0:
             self.mag_corr = True
         else:
             self.mag_corr = False
+            if np.nanmin(pixel_array) < 0:
+                warnings.warn('Negative values found in data from the first '
+                              'inversion but as the first percentile is not '
+                              'negative, it is assumed these are negative '
+                              'due to noise or preprocessing steps such as '
+                              'EPI distortion correction and registration. '
+                              'As such the data will be fit to the modulus of '
+                              'the recovery curve.\n'
+                              f'Min value = {np.nanmin(pixel_array[..., 0])}\n'
+                              '1st percentile = '
+                              f'{np.percentile(pixel_array[..., 0], 1)}')
 
         if self.parameters == 2:
             if self.mag_corr:

--- a/ukat/mapping/tests/test_b0.py
+++ b/ukat/mapping/tests/test_b0.py
@@ -71,9 +71,6 @@ class TestB0:
         masked_pixels = B0(self.correct_array, self.correct_echo_list,
                            self.affine, mask=mask)
 
-        assert (all_pixels.phase_difference !=
-                masked_pixels.phase_difference).any()
-        assert (all_pixels.b0_map != masked_pixels.b0_map).any()
         assert (arraystats.ArrayStats(all_pixels.b0_map).calculate() !=
                 arraystats.ArrayStats(masked_pixels.b0_map).calculate())
 

--- a/ukat/mapping/tests/test_t1.py
+++ b/ukat/mapping/tests/test_t1.py
@@ -262,6 +262,16 @@ class TestT1:
                         inversion_list=np.linspace(0, 2000, 10),
                         affine=self.affine, tss=1, tss_axis=2)
 
+    def test_mag_corr_warning(self):
+        # Make the absolute of the signal into a 4D array
+        signal_array = np.tile(np.abs(self.correct_signal_two_param),
+                               (10, 10, 3, 1))
+        # Add a single negative value to the signal
+        signal_array[0, 0, 0, 0] = -1
+
+        with pytest.warns(UserWarning):
+            mapper = T1(signal_array, self.t, self.affine, multithread=False)
+
     def test_molli_2p_warning(self):
         signal_array = np.tile(self.correct_signal_three_param, (10, 10, 3, 1))
         with pytest.warns(UserWarning):

--- a/ukat/mapping/tests/test_t1.py
+++ b/ukat/mapping/tests/test_t1.py
@@ -263,6 +263,9 @@ class TestT1:
                         affine=self.affine, tss=1, tss_axis=2)
 
     def test_mag_corr_warning(self):
+        # Test warning for small number of negative values thus assuming no
+        # magnitude correction has been performed
+
         # Make the absolute of the signal into a 4D array
         signal_array = np.tile(np.abs(self.correct_signal_two_param),
                                (10, 10, 3, 1))
@@ -271,6 +274,20 @@ class TestT1:
 
         with pytest.warns(UserWarning):
             mapper = T1(signal_array, self.t, self.affine, multithread=False)
+
+        # Test warning for enough negative values to assume magnitude
+        # correction has been performed but still not that many negative values
+
+        # Make the of the signal into a 4D array
+        signal_array = np.tile(np.abs(self.correct_signal_two_param),
+                               (10, 10, 3, 1))
+        # Add a row of signals with negative values to the image
+        # 3.3% of first inversion is negative but 1st percentile is negative.
+        signal_array[:, 0, 0, :] = self.correct_signal_two_param
+
+        with pytest.warns(UserWarning):
+            mapper = T1(signal_array, self.t, self.affine, multithread=False)
+
 
     def test_molli_2p_warning(self):
         signal_array = np.tile(self.correct_signal_three_param, (10, 10, 3, 1))


### PR DESCRIPTION
### Proposed changes

Data is now assumed to be magnitude corrected if the first percentile of the first inversion is negative rather than just the minimum value of the whole array. This should avoid the case where a user doesn't magnitude correct their data, but does distortion correct it and thus has a few negative voxels and `ukat` trying to fit all the data the a full inversion recovery rather than the absolute recovery.

Also warn the user the the number of negative voxels is close to the threshold where assumptions are made.

Will close #222

PR is to release branch to make life easier as I'm going to do the release soon anyway.

### Checklists

- [x] I have read and followed the [CONTRIBUTING](.github/CONTRIBUTING.md) document
- [ ] This pull request is from and to the dev branch
- [x] I have added tests that demonstrate the feature/fix works
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated documentation which becomes obsolete after my changes (if appropriate)
- [x] I have added/updated a notebook to demonstrate the changes (if appropriate)
- [x] Files added follow the repository structure (if appropriate)