### PR TITLE
Signal Normalisation and MOLLI T1 Bounds

### DIFF
--- a/ukat/mapping/t1.py
+++ b/ukat/mapping/t1.py
@@ -8,7 +8,7 @@ from . import fitting
 
 class T1Model(fitting.Model):
     def __init__(self, pixel_array, ti, parameters=2, mask=None, tss=0,
-                 tss_axis=-2, multithread=True):
+                 tss_axis=-2, molli=False, multithread=True):
         """
         A class containing the T1 fitting model
 
@@ -51,6 +51,7 @@ class T1Model(fitting.Model):
         self.parameters = parameters
         self.tss = tss
         self.tss_axis = tss_axis
+        self.molli = molli
 
         # Assume the data has been magnitude corrected if the first
         # percentile of the first inversion time is negative.
@@ -92,8 +93,8 @@ class T1Model(fitting.Model):
                 self.t1_eq = two_param_abs_eq
                 super().__init__(pixel_array, ti, self.t1_eq, mask,
                                  multithread)
-            self.bounds = ([0, 0], [5000, 1000000000])
-            self.initial_guess = [1000, 30000]
+            self.bounds = ([0, 0], [5000, 100])
+            self.initial_guess = [1000, 1]
         elif self.parameters == 3:
             if self.mag_corr:
                 self.t1_eq = three_param_eq
@@ -103,8 +104,12 @@ class T1Model(fitting.Model):
                 self.t1_eq = three_param_abs_eq
                 super().__init__(pixel_array, ti, self.t1_eq, mask,
                                  multithread)
-            self.bounds = ([0, 0, 1], [5000, 1000000000, 2])
-            self.initial_guess = [1000, 30000, 2]
+            if self.molli:
+                self.bounds = ([0, 0, 0], [5000, 100, 3])
+                self.initial_guess = [1000, 1, 2]
+            else:
+                self.bounds = ([0, 0, 1], [5000, 100, 2])
+                self.initial_guess = [1000, 1, 2]
         else:
             raise ValueError(f'Parameters can be 2 or 3 only. You specified '
                              f'{parameters}.')
@@ -207,8 +212,10 @@ class T1:
                or multithread == 'auto', f'multithreaded must be True,' \
                                          f'False or auto. You entered ' \
                                          f'{multithread}'
+        # Normalise the data so its roughly in the same range across vendors
+        self.scale = np.nanmax(pixel_array)
+        self.pixel_array = pixel_array / self.scale
 
-        self.pixel_array = pixel_array
         self.shape = pixel_array.shape[:-1]
         self.dimensions = len(pixel_array.shape)
         self.n_ti = pixel_array.shape[-1]
@@ -256,7 +263,8 @@ class T1:
         # Fit Data
         self.fitting_model = T1Model(self.pixel_array, self.inversion_list,
                                      self.parameters, self.mask, self.tss,
-                                     self.tss_axis, self.multithread)
+                                     self.tss_axis, self.molli,
+                                     self.multithread)
         popt, error, r2 = fitting.fit_image(self.fitting_model)
         self.t1_map = popt[0]
         self.m0_map = popt[1]
@@ -287,10 +295,15 @@ class T1:
 
         # Do MOLLI correction
         if self.molli:
-            correction_factor = (self.m0_map * self.eff_map) / self.m0_map - 1
+            correction_factor = (((self.m0_map * self.eff_map) / self.m0_map)
+                                 - 1)
             percentage_error = self.t1_err / self.t1_map
             self.t1_map = np.nan_to_num(self.t1_map * correction_factor)
             self.t1_err = np.nan_to_num(self.t1_map * percentage_error)
+
+        # Scale the data back to the original scale
+        self.m0_map = self.m0_map * self.scale
+        self.m0_err = self.m0_err * self.scale
 
     def r1_map(self):
         """

--- a/ukat/mapping/t1.py
+++ b/ukat/mapping/t1.py
@@ -302,8 +302,8 @@ class T1:
             self.t1_err = np.nan_to_num(self.t1_map * percentage_error)
 
         # Scale the data back to the original scale
-        self.m0_map = self.m0_map * self.scale
-        self.m0_err = self.m0_err * self.scale
+        self.m0_map *= self.scale
+        self.m0_err *= self.scale
 
     def r1_map(self):
         """

--- a/ukat/mapping/t2star.py
+++ b/ukat/mapping/t2star.py
@@ -35,8 +35,8 @@ class T2StarExpModel(fitting.Model):
         """
 
         super().__init__(pixel_array, te, two_param_eq, mask, multithread)
-        self.bounds = ([0, 0], [700, 100000000])
-        self.initial_guess = [20, 10000]
+        self.bounds = ([0, 0], [700, 100])
+        self.initial_guess = [20, 1]
         self.generate_lists()
 
 
@@ -117,7 +117,11 @@ class T2Star:
             or multithread is False \
             or multithread == 'auto', f'multithreaded must be True, False ' \
                                       f'or auto. You entered {multithread}'
-        self.pixel_array = pixel_array
+
+        # Normalise the data so its roughly in the same range across vendors
+        self.scale = np.nanmax(pixel_array)
+        self.pixel_array = pixel_array / self.scale
+
         self.shape = pixel_array.shape[:-1]
         self.n_te = pixel_array.shape[-1]
         self.n_vox = np.prod(self.shape)
@@ -184,6 +188,10 @@ class T2Star:
                               'in this regime. If these voxels are of '
                               'interest, consider using the 2p_exp fitting'
                               ' method'.format(proportion_less_than_20))
+
+        # Scale the data back to the original range
+        self.m0_map *= self.scale
+        self.m0_err *= self.scale
 
     def _loglin_fit(self):
         if self.multithread:

--- a/ukat/mapping/tests/test_t1.py
+++ b/ukat/mapping/tests/test_t1.py
@@ -65,8 +65,8 @@ class TestT1:
                                                595.68345494, 1014.80958915,
                                                1394.05059827]]
                                              ])
-    # Signal with all 9 elements equal to -5000 between 200 and 1000 ms
-    signal_fail_fit = -5000 * np.ones(9)
+    # Make some silly data that the code won't be able to fit any values to.
+    signal_fail_fit = np.arange(0, 9) % 2
     affine = np.eye(4)
 
     def test_two_param_eq(self):
@@ -126,7 +126,7 @@ class TestT1:
                     multithread=True)
         assert mapper.shape == signal_array.shape[:-1]
         npt.assert_almost_equal(mapper.t1_map.mean(), self.t1)
-        npt.assert_almost_equal(mapper.m0_map.mean(), self.m0)
+        npt.assert_almost_equal(mapper.m0_map.mean(), self.m0, decimal=4)
         npt.assert_almost_equal(mapper.eff_map.mean(), self.eff)
         npt.assert_almost_equal(mapper.r1_map().mean(), 1 / self.t1)
         npt.assert_almost_equal(mapper.r2.mean(), 1)
@@ -136,7 +136,7 @@ class TestT1:
                     multithread=False)
         assert mapper.shape == signal_array.shape[:-1]
         npt.assert_almost_equal(mapper.t1_map.mean(), self.t1)
-        npt.assert_almost_equal(mapper.m0_map.mean(), self.m0)
+        npt.assert_almost_equal(mapper.m0_map.mean(), self.m0, decimal=4)
         npt.assert_almost_equal(mapper.eff_map.mean(), self.eff)
         npt.assert_almost_equal(mapper.r1_map().mean(), 1 / self.t1)
         npt.assert_almost_equal(mapper.r2.mean(), 1)
@@ -164,7 +164,7 @@ class TestT1:
         signal_array = np.tile(self.signal_fail_fit, (10, 10, 3, 1))
 
         # Fail to fit using the 2 parameter equation
-        mapper_two_param = T1(signal_array, self.t, self.affine,
+        mapper_two_param = T1(signal_array[..., :2], self.t[:2], self.affine,
                               parameters=2, multithread=True)
         assert mapper_two_param.shape == signal_array.shape[:-1]
         # Voxels that fail to fit are set to zero
@@ -175,8 +175,8 @@ class TestT1:
         npt.assert_equal(mapper_two_param.r2.mean(), 0)
 
         # Fail to fit using the 3 parameter equation
-        mapper_three_param = T1(signal_array, self.t, self.affine,
-                                parameters=3, multithread=True)
+        mapper_three_param = T1(signal_array[..., :2], self.t[:2],
+                                self.affine, parameters=3, multithread=True)
         assert mapper_three_param.shape == signal_array.shape[:-1]
         # Voxels that fail to fit are set to zero
         npt.assert_equal(mapper_three_param.t1_map.mean(), 0)
@@ -311,10 +311,10 @@ class TestT1:
         image_molli = image_molli[70:90, 100:120, :2, :]
 
         # Gold standard statistics
-        gold_standard_2p = [1041.581031, 430.129308, 241.512336, 2603.911794]
-        gold_standard_3p = [1416.989523, 722.097507, 0.0, 4909.693108]
-        gold_standard_3p_single = [1379.242715, 714.21752, 0.0, 4308.23814]
-        gold_standard_molli = [1647.83798691, 741.68317391, 0.0, 4706.6919605]
+        gold_standard_2p = [1040.259477, 429.506592, 241.512334, 2603.911796]
+        gold_standard_3p = [1388.640507, 677.167604, 0.0, 4909.689015]
+        gold_standard_3p_single = [1347.824169, 657.254769, 0.0, 3948.24018]
+        gold_standard_molli = [1554.586501,  606.863022, -170.611303, 6025.763663]
 
         # Two parameter method
         mapper = T1(magnitude, ti, affine, parameters=2, tss=tss)
@@ -431,8 +431,8 @@ class TestT1:
         stats = arraystats.ArrayStats(fit_signal).calculate()
         npt.assert_allclose([stats["mean"]["4D"], stats["std"]["4D"],
                              stats["min"]["4D"], stats["max"]["4D"]],
-                            [5398.618239796042, 3125.641946762129,
-                             0.0, 12565.465983508042],
+                            [5.469067e+03, 2.982727e+03,
+                             2.613584e+00, 1.284273e+04],
                             rtol=1e-6, atol=1e-4)
 
 

--- a/ukat/mapping/tests/test_t1.py
+++ b/ukat/mapping/tests/test_t1.py
@@ -314,7 +314,8 @@ class TestT1:
         gold_standard_2p = [1040.259477, 429.506592, 241.512334, 2603.911796]
         gold_standard_3p = [1388.640507, 677.167604, 0.0, 4909.689015]
         gold_standard_3p_single = [1347.824169, 657.254769, 0.0, 3948.24018]
-        gold_standard_molli = [1554.586501,  606.863022, -170.611303, 6025.763663]
+        gold_standard_molli = [1554.586501,  606.863022, -170.611303,
+                               6025.763663]
 
         # Two parameter method
         mapper = T1(magnitude, ti, affine, parameters=2, tss=tss)

--- a/ukat/mapping/tests/test_t2.py
+++ b/ukat/mapping/tests/test_t2.py
@@ -151,8 +151,7 @@ class TestT2:
         # Gold standard statistics
         gold_standard_2p_exp = [105.63945, 39.616205,
                                 0.0, 568.160604]
-        gold_standard_3p_exp = [9.881218e+01, 4.294529e+01,
-                                3.489657e-02, 5.681606e+02]
+        gold_standard_3p_exp = [98.812108, 42.945342, 0.0, 568.160625]
         gold_standard_thresh = [106.351332, 39.904419,
                                 0.0, 568.160832]
 

--- a/ukat/mapping/tests/test_t2star.py
+++ b/ukat/mapping/tests/test_t2star.py
@@ -270,10 +270,8 @@ class TestT2Star:
         image = image[30:60, 50:90, 2, :]
 
         # Gold standard statistics for each method
-        gold_standard_loglin = [32.2660346964308, 18.499243841743308,
-                                0.0, 239.07407841896983]
-        gold_standard_2p_exp = [30.724443852557155, 22.156366883080896,
-                                0.0, 529.8640757093401]
+        gold_standard_loglin = [32.727562, 23.862456, 6.739695, 581.272145]
+        gold_standard_2p_exp = [30.724469, 22.156475, 0.0, 529.870475]
 
         # loglin method
         mapper = T2Star(image, te, self.affine, method='loglin')


### PR DESCRIPTION
### Proposed changes

M0 initialisation values were set based on Philips data. It makes more sense to normalise the data when its input to a mapper, fit the normalised data then rescale it back. This way M0 bounds and initial guesses are more sensible for other vendors.

In MOLLI fits, you can sometimes want efficiencies over 2. This PR also widens the bounds on T1 efficiency if `molli=True`.

### Checklists

- [x] I have read and followed the [CONTRIBUTING](.github/CONTRIBUTING.md) document
- [x] This pull request is from and to the dev branch
- [x] I have added tests that demonstrate the feature/fix works
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated documentation which becomes obsolete after my changes (if appropriate)
- [x] I have added/updated a notebook to demonstrate the changes (if appropriate)
- [x] Files added follow the repository structure (if appropriate)
